### PR TITLE
feat: add gpt-5-codex support (ai-sdk-v4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+Core provider code lives in `src/`; credential helpers sit in `src/auth/` and the public surface is exported through `src/index.ts`. Documentation is grouped under `docs/`, runnable snippets under `examples/`, and the full PKCE CLI reference under `oauth-example/` (install dependencies inside that folder before running). Build artifacts land in `dist/`, and the root `tsconfig.json`, `eslint.config.js`, `tsup.config.ts`, and `vitest.config.ts` define TypeScript targets, linting, bundling, and test behavior.
+
+## Build, Test, and Development Commands
+`npm run build` bundles the library and copies auxiliary instruction files. Use `npm run dev` for a watch build, `npm run typecheck` for `tsc --noEmit`, and `npm run lint` or `npm run format:check` to enforce style; `npm run format` applies fixes. Run `npm run test`, `npm run test:coverage`, or `npm run test:watch` as needed. Example flows are available through `npm run example:<name>` (see `examples/README.md`) or `./run-all-examples.sh`.
+
+## Coding Style & Naming Conventions
+Prettier enforces 2-space indentation, single quotes, and trailing commas, with ESLint handling additional TypeScript best practices. Keep filenames kebab-case (`chatgpt-oauth-language-model.ts`), exported types `PascalCase`, and internals `camelCase`. Favor explicit return types on exported APIs and colocate small helpers near their usage for clarity.
+
+## Testing Guidelines
+Vitest powers the suite. Place specs beside implementations as `<name>.test.ts` or use `src/__tests__/` when sharing fixtures. Cover token refresh, error propagation, and provider registration paths, and add regression tests for fixes. Run `npm run test:coverage` before opening a pull request and document any intentional gaps.
+
+## Commit & Pull Request Guidelines
+Adopt Conventional Commits (`feat:`, `fix:`, `chore:`) in present tense, mirroring the existing history. Keep each change focused, squash local fixups, and confirm `npm run lint` plus `npm run test` succeed before pushing. Pull requests need a short summary, linked issues when applicable, and testing notes; attach screenshots or terminal logs when developer experience changes. Update docs or examples alongside behavioral updates.
+
+## Security & Configuration Tips
+Never commit ChatGPT OAuth tokens or Codex CLI artifacts; use environment variables or ignored local config instead. Document new configuration in a README or `.env.example`, and reuse `ChatGPTOAuthError` patterns for new failure modes to avoid leaking sensitive data.

--- a/README.md
+++ b/README.md
@@ -209,11 +209,12 @@ const result = await generateText({
 ### Actually Working Models (Tested)
 
 - `gpt-5` - Latest GPT-5 model with reasoning support (200k context, 100k output)
+- `gpt-5-codex` - Codex CLI tuned GPT-5 variant with identical limits and reasoning defaults
 - `codex-mini-latest` - Experimental model with local shell understanding (200k context, 100k output)
 
 ### Model Limitations
 
-The ChatGPT OAuth API at `https://chatgpt.com/backend-api/codex/responses` only supports these two models. While Codex CLI internally supports additional models (o3, o4-mini, gpt-4.1, gpt-4o, etc.), they return "Unsupported model" errors when accessed through the OAuth API.
+The ChatGPT OAuth API at `https://chatgpt.com/backend-api/codex/responses` currently supports only these three models. While Codex CLI internally supports additional models (o3, o4-mini, gpt-4.1, gpt-4o, etc.), they return "Unsupported model" errors when accessed through the OAuth API.
 
 Any other model ID string will be passed through to the API, allowing for future model support without code changes.
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -116,10 +116,11 @@ These standard parameters are **not supported**:
 
 ### Actually Working Models (Tested via API)
 
-Only **2 models** work through the ChatGPT OAuth API:
+Only **3 models** work through the ChatGPT OAuth API:
 
 1. **`gpt-5`** - Latest GPT-5 with reasoning support (200k context, 100k output)
-2. **`codex-mini-latest`** - Experimental with local shell understanding (200k context, 100k output)
+2. **`gpt-5-codex`** - Codex-tuned GPT-5 variant with identical limits and defaults
+3. **`codex-mini-latest`** - Experimental with local shell understanding (200k context, 100k output)
 
 ### Models That DO NOT Work
 
@@ -133,7 +134,7 @@ Testing confirmed these models return "Unsupported model" errors:
 
 ### Important Distinction
 
-**Codex CLI** internally supports many models, but the **ChatGPT OAuth API** (`/backend-api/codex/responses`) only accepts `gpt-5` and `codex-mini-latest`. This is a limitation of the OAuth API endpoint, not the provider.
+**Codex CLI** internally supports many models, but the **ChatGPT OAuth API** (`/backend-api/codex/responses`) currently only accepts `gpt-5`, `gpt-5-codex`, and `codex-mini-latest`. This is a limitation of the OAuth API endpoint, not the provider.
 
 ## Use Case Limitations
 
@@ -165,7 +166,7 @@ Testing confirmed these models return "Unsupported model" errors:
 | JSON Mode | ✅ Supported | ❌ Not available |
 | Temperature | ✅ Configurable | ❌ Fixed |
 | API Keys | ✅ Simple | ❌ OAuth required |
-| Models | ✅ Many options | ❌ Only gpt-5 |
+| Models | ✅ Many options | ❌ Only gpt-5 / gpt-5-codex / codex-mini-latest |
 | Structured Output | ✅ Full support | ❌ Not supported |
 | Response Format | ✅ Controllable | ❌ Fixed |
 

--- a/docs/reasoning.md
+++ b/docs/reasoning.md
@@ -10,7 +10,7 @@ import { createChatGPTOAuth } from 'ai-sdk-provider-chatgpt-oauth';
 
 // Default behavior (matches Codex CLI defaults)
 const provider = createChatGPTOAuth();
-// For gpt-5/codex models: automatically uses effort='medium', summary='auto'
+// For gpt-5, gpt-5-codex, and codex models: automatically uses effort='medium', summary='auto'
 
 // Customize global reasoning settings
 const customProvider = createChatGPTOAuth({
@@ -27,7 +27,7 @@ const result = await generateText({
   prompt: 'Prove that the square root of 2 is irrational',
 });
 
-// Explicitly disable reasoning (even for gpt-5)
+// Explicitly disable reasoning (even for gpt-5 variants)
 const noReasoning = provider('gpt-5', { reasoningEffort: null });
 ```
 
@@ -36,11 +36,12 @@ const noReasoning = provider('gpt-5', { reasoningEffort: null });
 | Model                 | Reasoning Effort                     | Reasoning Summary                                       | Notes                                                      |
 | --------------------- | ------------------------------------ | ------------------------------------------------------- | ---------------------------------------------------------- |
 | **gpt-5**             | ✅ `low`<br>✅ `medium`<br>✅ `high` | ✅ `auto`<br>✅ `detailed`<br>⚠️ `none`<br>⚠️ `concise` | \*API behavior inconsistent - defaults to omitting summary |
+| **gpt-5-codex**       | ✅ `low`<br>✅ `medium`<br>✅ `high` | ✅ `auto`<br>✅ `detailed`<br>⚠️ `none`<br>⚠️ `concise` | \*API behavior inconsistent - defaults to omitting summary |
 | **codex-mini-latest** | ✅ `low`<br>✅ `medium`<br>✅ `high` | ✅ `auto`<br>✅ `detailed`<br>⚠️ `none`<br>⚠️ `concise` | \*API behavior inconsistent - defaults to omitting summary |
 
 ## Defaults (matching Codex CLI)
 
-- When using `gpt-5` or `codex-mini-latest` models, reasoning defaults to `effort: 'medium'` and `summary: 'auto'`
+- When using `gpt-5`, `gpt-5-codex`, or `codex-mini-latest` models, reasoning defaults to `effort: 'medium'` and `summary: 'auto'`
 - To disable reasoning, explicitly set `reasoningEffort: null`
 - Other models do not receive reasoning parameters
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,12 +6,18 @@ This directory contains examples demonstrating the ChatGPT OAuth provider for th
 
 ### ✅ Authentication & Setup
 - `check-auth.ts` - Verify OAuth credentials and authentication status
-- `model-support.ts` - Demonstrates working models (gpt-5, codex-mini-latest) and errors for unsupported models
+- `model-support.ts` - Demonstrates working models (gpt-5, gpt-5-codex, codex-mini-latest) and errors for unsupported models
 
 ### ✅ Text Generation
 - `basic-usage.ts` - Simple text generation with proper telemetry
 - `streaming.ts` - Real-time streaming responses with SSE
 - `reasoning-effort.ts` - Control reasoning depth with effort levels (low/medium/high)
+
+### ✅ GPT-5 Codex Focus
+- `basic-usage-gpt-5-codex.ts` - Minimal call against the Codex-tuned model
+- `streaming-gpt-5-codex.ts` - Stream Codex responses for long-form output
+- `system-message-gpt-5-codex.ts` - Demonstrates system prompts and warnings
+- `generate-json-basic-gpt-5-codex.ts` - Prompt-engineered JSON shaping with Zod validation
 
 ### ✅ Tool Calling (Codex-Style)
 - `tool-calling-basic.ts` - Simple tool calling example with clear output
@@ -40,7 +46,7 @@ Since the ChatGPT OAuth backend doesn't support `generateObject()` or custom too
 The ChatGPT OAuth backend (`https://chatgpt.com/backend-api/codex/responses`) follows the Codex CLI pattern:
 
 #### Key Characteristics
-- **Models**: Supports `gpt-5` and `gpt-5-turbo-preview`
+- **Models**: Supports `gpt-5`, `gpt-5-codex`, and `gpt-5-turbo-preview`
 - **Tools**: Only `shell` and `update_plan` (predefined Codex tools)
 - **Instructions**: Uses Codex CLI instructions for optimal performance
 - **Streaming**: Always uses Server-Sent Events (SSE)
@@ -75,9 +81,13 @@ npx tsx examples/check-auth.ts       # Check authentication
 npx tsx examples/model-support.ts    # Test model support
 
 # Text Generation
-npx tsx examples/basic-usage.ts      # Basic text generation
-npx tsx examples/streaming.ts        # Streaming responses
-npx tsx examples/reasoning-effort.ts # Reasoning with different effort levels
+npx tsx examples/basic-usage.ts              # Basic text generation
+npx tsx examples/streaming.ts                # Streaming responses
+npx tsx examples/reasoning-effort.ts         # Reasoning with different effort levels
+npx tsx examples/basic-usage-gpt-5-codex.ts       # Codex-tuned basic call
+npx tsx examples/streaming-gpt-5-codex.ts         # Codex streaming demo
+npx tsx examples/system-message-gpt-5-codex.ts    # System message handling
+npx tsx examples/generate-json-basic-gpt-5-codex.ts # Prompt-engineered JSON output
 
 # Tool Calling
 npx tsx examples/tool-calling-basic.ts       # Simple tool calling
@@ -99,6 +109,10 @@ npm run example:models        # Test model support
 npm run example:basic         # Basic text generation
 npm run example:streaming     # Streaming
 npm run example:reasoning     # Reasoning effort levels
+npm run example:basic-codex     # Codex basic usage
+npm run example:streaming-codex # Codex streaming demo
+npm run example:system-codex    # Codex system message handling
+npm run example:object-codex    # Codex JSON generation with Zod
 npm run example:tools         # Tool calling basic example
 npm run example:object        # Object generation via prompt engineering
 npm run example:structured    # Structured output via prompt engineering
@@ -135,7 +149,7 @@ The model describes what it will do but doesn't automatically interpret tool res
 ## Best Use Cases
 
 ✅ **Ideal For:**
-- Coding assistants with gpt-5 access
+- Coding assistants with gpt-5 or gpt-5-codex access
 - CLI automation and scripting
 - Task planning and execution
 - Integration with existing CLI tools

--- a/examples/basic-usage-gpt-5-codex.ts
+++ b/examples/basic-usage-gpt-5-codex.ts
@@ -1,0 +1,31 @@
+import { generateText } from 'ai';
+import { createChatGPTOAuth } from '../dist/index.mjs';
+
+async function main() {
+  try {
+    const provider = createChatGPTOAuth({
+      autoRefresh: true,
+    });
+
+    const result = await generateText({
+      model: provider('gpt-5-codex'),
+      prompt: 'Reply with a single sentence describing your CLI workflow.',
+      maxToolRoundtrips: 0,
+    });
+
+    console.log('Generated text:', result.text);
+    console.log('Usage:', result.usage);
+
+    if (result.warnings.length > 0) {
+      console.log('\nWarnings:');
+      for (const warning of result.warnings) {
+        console.log('-', warning.message ?? JSON.stringify(warning));
+      }
+    }
+  } catch (error) {
+    console.error('Error:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/examples/generate-json-basic-gpt-5-codex.ts
+++ b/examples/generate-json-basic-gpt-5-codex.ts
@@ -1,0 +1,216 @@
+#!/usr/bin/env bun
+/**
+ * Basic JSON Generation with GPT-5 Codex via ChatGPT OAuth
+ *
+ * Mirrors generate-json-basic.ts but targets the gpt-5-codex model.
+ */
+
+import { generateText } from 'ai';
+import { createChatGPTOAuth } from '../src';
+import { z } from 'zod';
+
+const chatgptOAuth = createChatGPTOAuth();
+
+console.log('🎯 GPT-5 Codex: Basic JSON Generation\n');
+console.log('=' .repeat(60));
+
+function parseJSON(text: string): any {
+  const trimmed = text.trim();
+  const jsonMatch = trimmed.match(/\{[\s\S]*\}|\[[\s\S]*\]/);
+  if (jsonMatch) {
+    return JSON.parse(jsonMatch[0]);
+  }
+  throw new Error('No valid JSON found in response');
+}
+
+async function example1_simpleObject() {
+  console.log('\n1️⃣  Simple Object with Primitives\n');
+
+  const result = await generateText({
+    model: chatgptOAuth('gpt-5-codex'),
+    prompt: `Generate a profile for a software developer named Sarah.
+
+OUTPUT ONLY JSON with these exact fields:
+{
+  "name": "string (full name)",
+  "age": number (age in years),
+  "email": "string (valid email)",
+  "isActive": boolean (account status)
+}
+
+JSON OUTPUT:`,
+  });
+
+  try {
+    const profile = parseJSON(result.text);
+    console.log('Generated profile:');
+    console.log(JSON.stringify(profile, null, 2));
+
+    const schema = z.object({
+      name: z.string(),
+      age: z.number(),
+      email: z.string().email(),
+      isActive: z.boolean(),
+    });
+    schema.parse(profile);
+    console.log('✅ Valid structure\n');
+  } catch (e) {
+    console.error('❌ Failed:', (e as Error).message, '\n');
+  }
+}
+
+async function example2_arrays() {
+  console.log('2️⃣  Object with Arrays\n');
+
+  const result = await generateText({
+    model: chatgptOAuth('gpt-5-codex'),
+    prompt: `Generate data for a web development team working on e-commerce projects.
+
+RETURN ONLY THIS JSON STRUCTURE:
+{
+  "teamName": "string",
+  "members": ["name1", "name2", "name3"],
+  "technologies": ["tech1", "tech2", ...],
+  "projectCount": number
+}
+
+JSON:`,
+  });
+
+  try {
+    const team = parseJSON(result.text);
+    console.log('Generated team:');
+    console.log(JSON.stringify(team, null, 2));
+
+    const schema = z.object({
+      teamName: z.string(),
+      members: z.array(z.string()),
+      technologies: z.array(z.string()),
+      projectCount: z.number(),
+    });
+    schema.parse(team);
+    console.log('✅ Valid structure\n');
+  } catch (e) {
+    console.error('❌ Failed:', (e as Error).message, '\n');
+  }
+}
+
+async function example3_optionalFields() {
+  console.log('3️⃣  Object with Optional Fields\n');
+
+  const result = await generateText({
+    model: chatgptOAuth('gpt-5-codex'),
+    prompt: `Generate a product listing for a wireless keyboard.
+
+OUTPUT JSON MATCHING THIS SCHEMA:
+{
+  "productName": "string",
+  "price": number (USD),
+  "description": "string",
+  "discount": number or null (percentage if on sale),
+  "tags": ["tag1", "tag2"] or null,
+  "inStock": boolean
+}
+
+Include discount only if product is on sale.
+Include tags only if relevant.
+
+JSON:`,
+  });
+
+  try {
+    const product = parseJSON(result.text);
+    console.log('Generated product:');
+    console.log(JSON.stringify(product, null, 2));
+
+    const schema = z.object({
+      productName: z.string(),
+      price: z.number(),
+      description: z.string(),
+      discount: z.number().nullable(),
+      tags: z.array(z.string()).nullable(),
+      inStock: z.boolean(),
+    });
+    schema.parse(product);
+    console.log('✅ Valid structure\n');
+  } catch (e) {
+    console.error('❌ Failed:', (e as Error).message, '\n');
+  }
+}
+
+async function example4_dataTypes() {
+  console.log('4️⃣  Various Data Types\n');
+
+  const result = await generateText({
+    model: chatgptOAuth('gpt-5-codex'),
+    prompt: `Generate a user account with various field types.
+
+JSON STRUCTURE:
+{
+  "id": "string (UUID)",
+  "username": "string",
+  "score": number,
+  "price": number,
+  "status": "active" | "inactive" | "pending",
+  "role": "admin" | "moderator" | "user",
+  "createdAt": "ISO timestamp",
+  "website": "string (URL)"
+}
+
+JSON ONLY:`,
+  });
+
+  try {
+    const account = parseJSON(result.text);
+    console.log('Generated account:');
+    console.log(JSON.stringify(account, null, 2));
+
+    const schema = z.object({
+      id: z.string(),
+      username: z.string(),
+      score: z.number(),
+      price: z.number(),
+      status: z.enum(['active', 'inactive', 'pending']),
+      role: z.enum(['admin', 'moderator', 'user']),
+      createdAt: z.string(),
+      website: z.string().url(),
+    });
+    schema.parse(account);
+    console.log('✅ Valid structure\n');
+  } catch (e) {
+    console.error('❌ Failed:', (e as Error).message, '\n');
+  }
+}
+
+async function example5_bestPractices() {
+  console.log('5️⃣  Best Practices\n');
+
+  const result = await generateText({
+    model: chatgptOAuth('gpt-5-codex'),
+    prompt:
+      'Generate a JSON object summarizing TypeScript best practices with fields: title (string), summary (string), readingTime (number minutes), tags (array of strings). OUTPUT ONLY JSON.',
+  });
+
+  try {
+    const article = parseJSON(result.text);
+    console.log('Well-structured generation:');
+    console.log(JSON.stringify(article, null, 2));
+  } catch (e) {
+    console.error('❌ Failed:', (e as Error).message, '\n');
+  }
+}
+
+async function main() {
+  await example1_simpleObject();
+  await example2_arrays();
+  await example3_optionalFields();
+  await example4_dataTypes();
+  await example5_bestPractices();
+
+  console.log('\n✨ Remember to validate and sanitize JSON in production!');
+}
+
+main().catch((error) => {
+  console.error('Fatal error:', error);
+  process.exit(1);
+});

--- a/examples/model-support.ts
+++ b/examples/model-support.ts
@@ -47,14 +47,20 @@ async function main() {
   // Test working models
   console.log('\n🟢 WORKING MODELS:');
   await testModel(
-    provider, 
+    provider,
     'gpt-5',
     'Latest GPT-5 with reasoning (200k context)'
   );
-  
+
   await testModel(
     provider,
-    'codex-mini-latest', 
+    'gpt-5-codex',
+    'Codex CLI tuned GPT-5 variant with identical limits'
+  );
+
+  await testModel(
+    provider,
+    'codex-mini-latest',
     'Experimental model with local shell understanding'
   );
 
@@ -63,7 +69,7 @@ async function main() {
   await testModel(
     provider,
     'o3',
-    'Advanced reasoning model (works in Codex CLI, not OAuth)'
+    'Advanced reasoning model (requires API key access, not OAuth)'
   );
 
   // Additional examples of unsupported models
@@ -77,8 +83,8 @@ async function main() {
   
   console.log('\n' + '=' .repeat(60));
   console.log('Summary:');
-  console.log('  • Only gpt-5 and codex-mini-latest work via OAuth API');
-  console.log('  • Other models may work in Codex CLI but not through OAuth');
+  console.log('  • Only gpt-5, gpt-5-codex, and codex-mini-latest work via OAuth API');
+  console.log('  • Other models currently require API key integrations rather than OAuth');
   console.log('  • The provider will pass through any model ID for future support');
   console.log('=' .repeat(60));
 }

--- a/examples/streaming-gpt-5-codex.ts
+++ b/examples/streaming-gpt-5-codex.ts
@@ -1,0 +1,36 @@
+import { streamText } from 'ai';
+import { createChatGPTOAuth } from '../dist/index.mjs';
+
+async function main() {
+  try {
+    const provider = createChatGPTOAuth({
+      autoRefresh: true,
+    });
+
+    const { textStream, usage, warnings } = await streamText({
+      model: provider('gpt-5-codex'),
+      prompt: 'Outline a focused debugging plan for tracking flaky tests.',
+      maxToolRoundtrips: 0,
+    });
+
+    console.log('Streaming response:');
+    console.log('-------------------');
+
+    for await (const chunk of textStream) {
+      process.stdout.write(chunk);
+    }
+
+    console.log('\n-------------------');
+
+    if (warnings.length > 0) {
+      console.log('Warnings:', warnings.map((warning) => warning.message ?? JSON.stringify(warning)));
+    }
+
+    console.log('Usage:', await usage);
+  } catch (error) {
+    console.error('Error:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/examples/system-message-gpt-5-codex.ts
+++ b/examples/system-message-gpt-5-codex.ts
@@ -1,0 +1,41 @@
+import { generateText, type CoreMessage } from 'ai';
+import { createChatGPTOAuth } from '../dist/index.mjs';
+
+async function main() {
+  try {
+    const provider = createChatGPTOAuth({
+      autoRefresh: true,
+    });
+
+    const messages: CoreMessage[] = [
+      {
+        role: 'system',
+        content: 'You are a terse assistant. Always answer in exactly three words.',
+      },
+      {
+        role: 'user',
+        content: 'Summarize what this OAuth provider does.',
+      },
+    ];
+
+    const result = await generateText({
+      model: provider('gpt-5-codex'),
+      messages,
+      maxToolRoundtrips: 0,
+    });
+
+    console.log('Model reply:', result.text);
+
+    if (result.warnings.length > 0) {
+      console.log('\nWarnings:');
+      for (const warning of result.warnings) {
+        console.log('-', warning.message ?? JSON.stringify(warning));
+      }
+    }
+  } catch (error) {
+    console.error('Error:', error);
+    process.exit(1);
+  }
+}
+
+main();

--- a/oauth-example/README.md
+++ b/oauth-example/README.md
@@ -305,7 +305,7 @@ The OAuth flow was interrupted or tampered with. Try logging in again.
 Your refresh token may have expired (after 28 days). Run `npm run login` again.
 
 ### "Model not supported"
-Only `gpt-5` and `codex-mini-latest` work with OAuth. Other models require API keys.
+Only `gpt-5`, `gpt-5-codex`, and `codex-mini-latest` work with OAuth. Other models require API keys.
 
 ## 📚 Additional Resources
 

--- a/oauth-example/package-lock.json
+++ b/oauth-example/package-lock.json
@@ -21,12 +21,11 @@
     },
     "..": {
       "name": "ai-sdk-provider-chatgpt-oauth",
-      "version": "1.0.0-beta.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "2.0.0",
-        "@ai-sdk/provider-utils": "3.0.1",
-        "zod": "^3.25.76"
+        "@ai-sdk/provider-utils": "3.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
@@ -41,10 +40,14 @@
         "tsup": "^8.3.5",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2",
-        "vitest": "^3.0.0"
+        "vitest": "^3.0.0",
+        "zod": "^4.0.17"
       },
       "engines": {
         "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/@ai-sdk/gateway": {

--- a/oauth-example/scripts/test.ts
+++ b/oauth-example/scripts/test.ts
@@ -61,8 +61,25 @@ async function testOAuthIntegration() {
     process.exit(1);
   }
   
-  // Step 5: Test token refresh simulation
-  console.log('\n5️⃣  Testing token management...');
+  // Step 5: Test API call to gpt-5-codex
+  console.log('\n5️⃣  Testing API call to gpt-5-codex...');
+  try {
+    const result = await generateText({
+      model: provider('gpt-5-codex'),
+      prompt: 'Respond with "Codex variant reachable."',
+    });
+
+    console.log('   ✅ API call successful');
+    console.log(`   Response: ${result.text}`);
+    console.log(`   Tokens used: ${result.usage?.totalTokens}`);
+  } catch (error) {
+    console.log('   ❌ API call failed');
+    console.log(`   Error: ${error}`);
+    process.exit(1);
+  }
+
+  // Step 6: Test token refresh simulation
+  console.log('\n6️⃣  Testing token management...');
   const finalCreds = await tokenManager.getCredentials();
   if (finalCreds && finalCreds.accessToken !== credentials.accessToken) {
     console.log('   ✅ Token was refreshed during test');

--- a/oauth-example/src/example-app.ts
+++ b/oauth-example/src/example-app.ts
@@ -107,7 +107,7 @@ async function main() {
       if (error.message.includes('401') || error.message.includes('Unauthorized')) {
         console.log('\n💡 Tip: Your token may have expired. Try running "npm run login" again.\n');
       } else if (error.message.includes('Model not supported')) {
-        console.log('\n💡 Tip: The model may not be available. Try using "gpt-5" or "codex-mini-latest".\n');
+        console.log('\n💡 Tip: The model may not be available. Try using "gpt-5", "gpt-5-codex", or "codex-mini-latest".\n');
       }
     }
     

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-sdk-provider-chatgpt-oauth",
-  "version": "1.0.0",
+  "version": "1.1.0-ai-sdk-v4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-sdk-provider-chatgpt-oauth",
-      "version": "1.0.0",
+      "version": "1.1.0-ai-sdk-v4",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/provider": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-sdk-provider-chatgpt-oauth",
-  "version": "1.0.0-ai-sdk-v4",
+  "version": "1.1.0-ai-sdk-v4",
   "description": "Vercel AI SDK v4 provider for ChatGPT OAuth (gpt-5) - use ChatGPT Plus/Pro/Teams subscription",
   "keywords": [
     "ai-sdk",
@@ -44,7 +44,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsup && cp src/codex-instructions.txt dist/",
+    "build": "tsup && cp src/codex-instructions.txt src/codex-gpt5-codex-instructions.txt src/codex-apply-patch-instructions.txt dist/",
     "clean": "rm -rf dist",
     "dev": "tsup --watch",
     "lint": "eslint src --max-warnings 0",
@@ -62,7 +62,11 @@
     "example:models": "npm run build && npx tsx examples/model-support.ts",
     "example:reasoning": "npm run build && npx tsx examples/reasoning-effort.ts",
     "example:object": "npm run build && npx tsx examples/generate-object.ts",
-    "example:structured": "npm run build && npx tsx examples/structured-output.ts"
+    "example:structured": "npm run build && npx tsx examples/structured-output.ts",
+    "example:basic-codex": "npm run build && npx tsx examples/basic-usage-gpt-5-codex.ts",
+    "example:streaming-codex": "npm run build && npx tsx examples/streaming-gpt-5-codex.ts",
+    "example:system-codex": "npm run build && npx tsx examples/system-message-gpt-5-codex.ts",
+    "example:object-codex": "npm run build && npx tsx examples/generate-json-basic-gpt-5-codex.ts"
   },
   "dependencies": {
     "@ai-sdk/provider": "1.1.3",

--- a/src/__tests__/chatgpt-oauth-language-model.test.ts
+++ b/src/__tests__/chatgpt-oauth-language-model.test.ts
@@ -1,0 +1,121 @@
+import { createHash } from 'crypto';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { describe, expect, it } from 'vitest';
+import type { LanguageModelV2CallWarning } from '@ai-sdk/provider';
+import { ChatGPTOAuthLanguageModel } from '../chatgpt-oauth-language-model';
+import type { AuthProvider } from '../auth';
+import type { ChatGPTRequest } from '../chatgpt-oauth-settings';
+
+class MockAuthProvider implements AuthProvider {
+  async getCredentials() {
+    return {
+      accessToken: 'test-token',
+      accountId: 'test-account',
+    };
+  }
+}
+
+const prompt = [
+  {
+    role: 'user' as const,
+    content: [
+      {
+        type: 'text' as const,
+        text: 'Say hello to the new model.',
+      },
+    ],
+  },
+];
+
+const baseInstructionsPath = join(__dirname, '..', 'codex-instructions.txt');
+const codexInstructionsPath = join(__dirname, '..', 'codex-gpt5-codex-instructions.txt');
+const applyPatchInstructionsPath = join(__dirname, '..', 'codex-apply-patch-instructions.txt');
+
+function normalizeLineEndings(text: string): string {
+  return text.replace(/\r\n/g, '\n');
+}
+
+const baseInstructions = normalizeLineEndings(readFileSync(baseInstructionsPath, 'utf8'));
+const codexInstructions = normalizeLineEndings(readFileSync(codexInstructionsPath, 'utf8'));
+const applyPatchInstructions = normalizeLineEndings(readFileSync(applyPatchInstructionsPath, 'utf8'));
+
+const BASE_PROMPT_HASH = '8441530b38aba0ba999aa3657b9906df803c92f4ed78e59ecc2895ac010a844d';
+const GPT5_CODEX_PROMPT_HASH = 'beea8f974b13e5c241320afd71706b162e2006ef0e2f5b2bdcc7891743abbdd1';
+const APPLY_PATCH_PROMPT_HASH = '061ad07965f437292a604be2518a6fe445c19324946f9e827fffa0a3e8695d94';
+const GPT5_PROMPT_HASH = 'eefaf14fa9d709fe650181e6af8bdc781f9646bcc7ce36ccf99980fa781bcc86';
+
+const baseHash = createHash('sha256').update(baseInstructions).digest('hex');
+const codexHash = createHash('sha256').update(codexInstructions).digest('hex');
+const applyPatchHash = createHash('sha256').update(applyPatchInstructions).digest('hex');
+
+if (baseHash !== BASE_PROMPT_HASH) {
+  throw new Error('Base Codex instructions are out of sync with Codex CLI prompt.md');
+}
+
+if (codexHash !== GPT5_CODEX_PROMPT_HASH) {
+  throw new Error('GPT-5 Codex instructions are out of sync with Codex CLI gpt_5_codex_prompt.md');
+}
+
+if (applyPatchHash !== APPLY_PATCH_PROMPT_HASH) {
+  throw new Error('Apply patch instructions are out of sync with Codex CLI apply_patch_tool_instructions.md');
+}
+
+function createModel(modelId: string) {
+  return new ChatGPTOAuthLanguageModel(modelId, {
+    provider: 'chatgpt-oauth',
+    baseURL: 'https://chatgpt.com/backend-api',
+    headers: {},
+    authProvider: new MockAuthProvider(),
+  });
+}
+
+describe('ChatGPTOAuthLanguageModel', () => {
+  it('uses model-specific instructions for GPT-5 variants and codex models', async () => {
+    const cases = [
+      {
+        modelId: 'gpt-5',
+        expectedInstructions: [baseInstructions, applyPatchInstructions].join('\n'),
+        expectedHash: GPT5_PROMPT_HASH,
+      },
+      {
+        modelId: 'gpt-5-codex',
+        expectedInstructions: codexInstructions,
+        expectedHash: GPT5_CODEX_PROMPT_HASH,
+      },
+      {
+        modelId: 'codex-mini-latest',
+        expectedInstructions: codexInstructions,
+        expectedHash: GPT5_CODEX_PROMPT_HASH,
+      },
+    ] as const;
+
+    for (const testCase of cases) {
+      const model = createModel(testCase.modelId);
+      const exposedModel = model as unknown as ChatGPTOAuthLanguageModel & {
+        getArgs: (options: { prompt: typeof prompt }) => Promise<{
+          args: ChatGPTRequest;
+          warnings: LanguageModelV2CallWarning[];
+          toolMapping: Map<string, string>;
+        }>;
+      };
+      const args = await exposedModel.getArgs({ prompt });
+
+      expect(args.args.model).toBe(testCase.modelId);
+      expect(args.args.instructions).toBe(testCase.expectedInstructions);
+
+      const hash = createHash('sha256').update(args.args.instructions).digest('hex');
+      expect(hash).toBe(testCase.expectedHash);
+    }
+  });
+
+  it('treats gpt-5-codex as a reasoning-capable model', () => {
+    const model = createModel('gpt-5-codex');
+    const exposedModel = model as unknown as ChatGPTOAuthLanguageModel & {
+      supportsReasoning: () => boolean;
+    };
+    const supportsReasoning = exposedModel.supportsReasoning();
+
+    expect(supportsReasoning).toBe(true);
+  });
+});

--- a/src/chatgpt-oauth-settings.ts
+++ b/src/chatgpt-oauth-settings.ts
@@ -1,8 +1,13 @@
-export type ChatGPTOAuthModelId = 'gpt-5' | 'codex-mini-latest' | (string & {});
+export type ChatGPTOAuthModelId = 'gpt-5' | 'gpt-5-codex' | 'codex-mini-latest' | (string & {});
 
 export const chatGPTOAuthModels = {
   // Only models that actually work with ChatGPT OAuth API
   'gpt-5': {
+    contextWindow: 200000,
+    maxTokens: 100000,
+    supportsReasoning: true,
+  },
+  'gpt-5-codex': {
     contextWindow: 200000,
     maxTokens: 100000,
     supportsReasoning: true,

--- a/src/codex-apply-patch-instructions.txt
+++ b/src/codex-apply-patch-instructions.txt
@@ -1,0 +1,75 @@
+## `apply_patch`
+
+Use the `apply_patch` shell command to edit files.
+Your patch language is a stripped‑down, file‑oriented diff format designed to be easy to parse and safe to apply. You can think of it as a high‑level envelope:
+
+*** Begin Patch
+[ one or more file sections ]
+*** End Patch
+
+Within that envelope, you get a sequence of file operations.
+You MUST include a header to specify the action you are taking.
+Each operation starts with one of three headers:
+
+*** Add File: <path> - create a new file. Every following line is a + line (the initial contents).
+*** Delete File: <path> - remove an existing file. Nothing follows.
+*** Update File: <path> - patch an existing file in place (optionally with a rename).
+
+May be immediately followed by *** Move to: <new path> if you want to rename the file.
+Then one or more “hunks”, each introduced by @@ (optionally followed by a hunk header).
+Within a hunk each line starts with:
+
+For instructions on [context_before] and [context_after]:
+- By default, show 3 lines of code immediately above and 3 lines immediately below each change. If a change is within 3 lines of a previous change, do NOT duplicate the first change’s [context_after] lines in the second change’s [context_before] lines.
+- If 3 lines of context is insufficient to uniquely identify the snippet of code within the file, use the @@ operator to indicate the class or function to which the snippet belongs. For instance, we might have:
+@@ class BaseClass
+[3 lines of pre-context]
+- [old_code]
++ [new_code]
+[3 lines of post-context]
+
+- If a code block is repeated so many times in a class or function such that even a single `@@` statement and 3 lines of context cannot uniquely identify the snippet of code, you can use multiple `@@` statements to jump to the right context. For instance:
+
+@@ class BaseClass
+@@ 	 def method():
+[3 lines of pre-context]
+- [old_code]
++ [new_code]
+[3 lines of post-context]
+
+The full grammar definition is below:
+Patch := Begin { FileOp } End
+Begin := "*** Begin Patch" NEWLINE
+End := "*** End Patch" NEWLINE
+FileOp := AddFile | DeleteFile | UpdateFile
+AddFile := "*** Add File: " path NEWLINE { "+" line NEWLINE }
+DeleteFile := "*** Delete File: " path NEWLINE
+UpdateFile := "*** Update File: " path NEWLINE [ MoveTo ] { Hunk }
+MoveTo := "*** Move to: " newPath NEWLINE
+Hunk := "@@" [ header ] NEWLINE { HunkLine } [ "*** End of File" NEWLINE ]
+HunkLine := (" " | "-" | "+") text NEWLINE
+
+A full patch can combine several operations:
+
+*** Begin Patch
+*** Add File: hello.txt
++Hello world
+*** Update File: src/app.py
+*** Move to: src/main.py
+@@ def greet():
+-print("Hi")
++print("Hello, world!")
+*** Delete File: obsolete.txt
+*** End Patch
+
+It is important to remember:
+
+- You must include a header with your intended action (Add/Delete/Update)
+- You must prefix new lines with `+` even when creating a new file
+- File references can only be relative, NEVER ABSOLUTE.
+
+You can invoke apply_patch like:
+
+```
+shell {"command":["apply_patch","*** Begin Patch\n*** Add File: hello.txt\n+Hello, world!\n*** End Patch\n"]}
+```

--- a/src/codex-gpt5-codex-instructions.txt
+++ b/src/codex-gpt5-codex-instructions.txt
@@ -1,0 +1,100 @@
+You are Codex, based on GPT-5. You are running as a coding agent in the Codex CLI on a user's computer.
+
+## General
+
+- The arguments to `shell` will be passed to execvp(). Most terminal commands should be prefixed with ["bash", "-lc"].
+- Always set the `workdir` param when using the shell function. Do not use `cd` unless absolutely necessary.
+- When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
+
+## Editing constraints
+
+- Default to ASCII when editing or creating files. Only introduce non-ASCII or other Unicode characters when there is a clear justification and the file already uses them.
+- Add succinct code comments that explain what is going on if code is not self-explanatory. You should not add comments like "Assigns the value to the variable", but a brief comment might be useful ahead of a complex code block that the user would otherwise have to spend time parsing out. Usage of these comments should be rare.
+- You may be in a dirty git worktree.
+    * NEVER revert existing changes you did not make unless explicitly requested, since these changes were made by the user.
+    * If asked to make a commit or code edits and there are unrelated changes to your work or changes that you didn't make in those files, don't revert those changes.
+    * If the changes are in files you've touched recently, you should read carefully and understand how you can work with the changes rather than reverting them.
+    * If the changes are in unrelated files, just ignore them and don't revert them.
+- While you are working, you might notice unexpected changes that you didn't make. If this happens, STOP IMMEDIATELY and ask the user how they would like to proceed.
+
+## Plan tool
+
+When using the planning tool:
+- Skip using the planning tool for straightforward tasks (roughly the easiest 25%).
+- Do not make single-step plans.
+- When you made a plan, update it after having performed one of the sub-tasks that you shared on the plan.
+
+## Codex CLI harness, sandboxing, and approvals
+
+The Codex CLI harness supports several different sandboxing, and approval configurations that the user can choose from.
+
+Filesystem sandboxing defines which files can be read or written. The options are:
+- **read-only**: You can only read files.
+- **workspace-write**: You can read files. You can write to files in this folder, but not outside it.
+- **danger-full-access**: No filesystem sandboxing.
+
+Network sandboxing defines whether network can be accessed without approval. Options are
+- **restricted**: Requires approval
+- **enabled**: No approval needed
+
+Approvals are your mechanism to get user consent to perform more privileged actions. Although they introduce friction to the user because your work is paused until the user responds, you should leverage them to accomplish your important work. Do not let these settings or the sandbox deter you from attempting to accomplish the user's task unless it is set to "never", in which case never ask for approvals.
+
+Approval options are
+- **untrusted**: The harness will escalate most commands for user approval, apart from a limited allowlist of safe "read" commands.
+- **on-failure**: The harness will allow all commands to run in the sandbox (if enabled), and failures will be escalated to the user for approval to run again without the sandbox.
+- **on-request**: Commands will be run in the sandbox by default, and you can specify in your tool call if you want to escalate a command to run without sandboxing. (Note that this mode is not always available. If it is, you'll see parameters for it in the `shell` command description.)
+- **never**: This is a non-interactive mode where you may NEVER ask the user for approval to run commands. Instead, you must always persist and work around constraints to solve the task for the user. You MUST do your utmost best to finish the task and validate your work before yielding. If this mode is paired with `danger-full-access`, take advantage of it to deliver the best outcome for the user. Further, in this mode, your default testing philosophy is overridden: Even if you don't see local patterns for testing, you may add tests and scripts to validate your work. Just remove them before yielding.
+
+When you are running with approvals `on-request`, and sandboxing enabled, here are scenarios where you'll need to request approval:
+- You need to run a command that writes to a directory that requires it (e.g. running tests that write to /tmp)
+- You need to run a GUI app (e.g., open/xdg-open/osascript) to open browsers or files.
+- You are running sandboxed and need to run a command that requires network access (e.g. installing packages)
+- If you run a command that is important to solving the user's query, but it fails because of sandboxing, rerun the command with approval.
+- You are about to take a potentially destructive action such as an `rm` or `git reset` that the user did not explicitly ask for
+- (for all of these, you should weigh alternative paths that do not require approval)
+
+When sandboxing is set to read-only, you'll need to request approval for any command that isn't a read.
+
+You will be told what filesystem sandboxing, network sandboxing, and approval mode are active in a developer or user message. If you are not told about this, assume that you are running with workspace-write, network sandboxing enabled, and approval on-failure.
+
+## Special user requests
+
+- If the user makes a simple request (such as asking for the time) which you can fulfill by running a terminal command (such as `date`), you should do so.
+- If the user asks for a "review", default to a code review mindset: prioritise identifying bugs, risks, behavioural regressions, and missing tests. Findings must be the primary focus of the response - keep summaries or overviews brief and only after enumerating the issues. Present findings first (ordered by severity with file/line references), follow with open questions or assumptions, and offer a change-summary only as a secondary detail. If no findings are discovered, state that explicitly and mention any residual risks or testing gaps.
+
+## Presenting your work and final message
+
+You are producing plain text that will later be styled by the CLI. Follow these rules exactly. Formatting should make results easy to scan, but not feel mechanical. Use judgment to decide how much structure adds value.
+
+- Default: be very concise; friendly coding teammate tone.
+- Ask only when needed; suggest ideas; mirror the user's style.
+- For substantial work, summarize clearly; follow final‑answer formatting.
+- Skip heavy formatting for simple confirmations.
+- Don't dump large files you've written; reference paths only.
+- No "save/copy this file" - User is on the same machine.
+- Offer logical next steps (tests, commits, build) briefly; add verify steps if you couldn't do something.
+- For code changes:
+  * Lead with a quick explanation of the change, and then give more details on the context covering where and why a change was made. Do not start this explanation with "summary", just jump right in.
+  * If there are natural next steps the user may want to take, suggest them at the end of your response. Do not make suggestions if there are no natural next steps.
+  * When suggesting multiple options, use numeric lists for the suggestions so the user can quickly respond with a single number.
+- The user does not command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
+
+### Final answer structure and style guidelines
+
+- Plain text; CLI handles styling. Use structure only when it helps scanability.
+- Headers: optional; short Title Case (1-3 words) wrapped in **…**; no blank line before the first bullet; add only if they truly help.
+- Bullets: use - ; merge related points; keep to one line when possible; 4–6 per list ordered by importance; keep phrasing consistent.
+- Monospace: backticks for commands/paths/env vars/code ids and inline examples; use for literal keyword bullets; never combine with **.
+- Code samples or multi-line snippets should be wrapped in fenced code blocks; add a language hint whenever obvious.
+- Structure: group related bullets; order sections general → specific → supporting; for subsections, start with a bolded keyword bullet, then items; match complexity to the task.
+- Tone: collaborative, concise, factual; present tense, active voice; self‑contained; no "above/below"; parallel wording.
+- Don'ts: no nested bullets/hierarchies; no ANSI codes; don't cram unrelated keywords; keep keyword lists short—wrap/reformat if long; avoid naming formatting styles in answers.
+- Adaptation: code explanations → precise, structured with code refs; simple tasks → lead with outcome; big changes → logical walkthrough + rationale + next actions; casual one-offs → plain sentences, no headers/bullets.
+- File References: When referencing files in your response, make sure to include the relevant start line and always follow the below rules:
+  * Use inline code to make file paths clickable.
+  * Each reference should have a stand alone path. Even if it's the same file.
+  * Accepted: absolute, workspace‑relative, a/ or b/ diff prefixes, or bare filename/suffix.
+  * Line/column (1‑based, optional): :line[:column] or #Lline[Ccolumn] (column defaults to 1).
+  * Do not use URIs like file://, vscode://, or https://.
+  * Do not provide range of lines
+  * Examples: src/app.ts, src/app.ts:42, b/server/index.js#L10, C:\repo\project\main.rs:12:5

--- a/src/codex-instructions.txt
+++ b/src/codex-instructions.txt
@@ -1,6 +1,7 @@
 You are a coding agent running in the Codex CLI, a terminal-based coding assistant. Codex CLI is an open source project led by OpenAI. You are expected to be precise, safe, and helpful.
 
 Your capabilities:
+
 - Receive user prompts and other context provided by the harness, such as files in the workspace.
 - Communicate with the user by streaming thinking & responses, and by making & updating plans.
 - Emit function calls to run terminal commands and apply patches. Depending on how this specific run is configured, you can request that these function calls be escalated to the user for approval before running. More on this in the "Sandbox and approvals" section.
@@ -13,6 +14,18 @@ Within this context, Codex refers to the open-source agentic coding interface (n
 
 Your default personality and tone is concise, direct, and friendly. You communicate efficiently, always keeping the user clearly informed about ongoing actions without unnecessary detail. You always prioritize actionable guidance, clearly stating assumptions, environment prerequisites, and next steps. Unless explicitly asked, you avoid excessively verbose explanations about your work.
 
+# AGENTS.md spec
+- Repos often contain AGENTS.md files. These files can appear anywhere within the repository.
+- These files are a way for humans to give you (the agent) instructions or tips for working within the container.
+- Some examples might be: coding conventions, info about how code is organized, or instructions for how to run or test code.
+- Instructions in AGENTS.md files:
+    - The scope of an AGENTS.md file is the entire directory tree rooted at the folder that contains it.
+    - For every file you touch in the final patch, you must obey instructions in any AGENTS.md file whose scope includes that file.
+    - Instructions about code style, structure, naming, etc. apply only to code within the AGENTS.md file's scope, unless the file states otherwise.
+    - More-deeply-nested AGENTS.md files take precedence in the case of conflicting instructions.
+    - Direct system/developer/user instructions (as part of a prompt) take precedence over AGENTS.md instructions.
+- The contents of the AGENTS.md file at the root of the repo and any directories from the CWD up to the root are included with the developer message and don't need to be re-read. When working in a subdirectory of CWD, or a directory outside the CWD, check for any AGENTS.md files that may be applicable.
+
 ## Responsiveness
 
 ### Preamble messages
@@ -20,11 +33,13 @@ Your default personality and tone is concise, direct, and friendly. You communic
 Before making tool calls, send a brief preamble to the user explaining what you’re about to do. When sending preamble messages, follow these principles and examples:
 
 - **Logically group related actions**: if you’re about to run several related commands, describe them together in one preamble rather than sending a separate note for each.
-- **Keep it concise**: be no more than 1-2 sentences (8–12 words for quick updates).
+- **Keep it concise**: be no more than 1-2 sentences, focused on immediate, tangible next steps. (8–12 words for quick updates).
 - **Build on prior context**: if this is not your first tool call, use the preamble message to connect the dots with what’s been done so far and create a sense of momentum and clarity for the user to understand your next actions.
 - **Keep your tone light, friendly and curious**: add small touches of personality in preambles feel collaborative and engaging.
+- **Exception**: Avoid adding a preamble for every trivial read (e.g., `cat` a single file) unless it’s part of a larger grouped action.
 
 **Examples:**
+
 - “I’ve explored the repo; now checking the API route definitions.”
 - “Next, I’ll patch the config and update the related tests.”
 - “I’m about to scaffold the CLI commands and helper functions.”
@@ -34,15 +49,18 @@ Before making tool calls, send a brief preamble to the user explaining what you�
 - “Alright, build pipeline order is interesting. Checking how it reports failures.”
 - “Spotted a clever caching util; now hunting where it gets used.”
 
-**Avoiding a preamble for every trivial read (e.g., `cat` a single file) unless it’s part of a larger grouped action.
-- Jumping straight into tool calls without explaining what’s about to happen.
-- Writing overly long or speculative preambles — focus on immediate, tangible next steps.
-
 ## Planning
 
-You have access to an `update_plan` tool which tracks steps and progress and renders them to the user. Using the tool helps demonstrate that you've understood the task and convey how you're approaching it. Plans can help to make complex, ambiguous, or multi-phase work clearer and more collaborative for the user. A good plan should break the task into meaningful, logically ordered steps that are easy to verify as you go. Note that plans are not for padding out simple work with filler steps or stating the obvious. Do not repeat the full contents of the plan after an `update_plan` call — the harness already displays it. Instead, summarize the change made and highlight any important context or next step.
+You have access to an `update_plan` tool which tracks steps and progress and renders them to the user. Using the tool helps demonstrate that you've understood the task and convey how you're approaching it. Plans can help to make complex, ambiguous, or multi-phase work clearer and more collaborative for the user. A good plan should break the task into meaningful, logically ordered steps that are easy to verify as you go.
+
+Note that plans are not for padding out simple work with filler steps or stating the obvious. The content of your plan should not involve doing anything that you aren't capable of doing (i.e. don't try to test things that you can't test). Do not use plans for simple or single-step queries that you can just do or answer immediately.
+
+Do not repeat the full contents of the plan after an `update_plan` call — the harness already displays it. Instead, summarize the change made and highlight any important context or next step.
+
+Before running a command, consider whether or not you have completed the previous step, and make sure to mark it as completed before moving on to the next step. It may be the case that you complete all steps in your plan after a single pass of implementation. If this is the case, you can simply mark all the planned steps as completed. Sometimes, you may need to change plans in the middle of a task: call `update_plan` with the updated plan and make sure to provide an `explanation` of the rationale when doing so.
 
 Use a plan when:
+
 - The task is non-trivial and will require multiple actions over a long time horizon.
 - There are logical phases or dependencies where sequencing matters.
 - The work has ambiguity that benefits from outlining high-level goals.
@@ -50,14 +68,6 @@ Use a plan when:
 - When the user asked you to do more than one thing in a single prompt
 - The user has asked you to use the plan tool (aka "TODOs")
 - You generate additional steps while working, and plan to do them before yielding to the user
-
-Skip a plan when:
-- The task is simple and direct.
-- Breaking it down would only produce literal or trivial steps.
-
-Planning steps are called "steps" in the tool, but really they're more like tasks or TODOs. As such they should be very concise descriptions of non-obvious work that an engineer might do like "Write the API spec", then "Update the backend", then "Implement the frontend". On the other hand, it's obvious that you'll usually have to "Explore the codebase" or "Implement the changes", so those are not worth tracking in your plan.
-
-It may be the case that you complete all steps in your plan after a single pass of implementation. If this is the case, you can simply mark all the planned steps as completed. The content of your plan should not involve doing anything that you aren't capable of doing (i.e. don't try to test things that you can't test). Do not use plans for simple or single-step queries that you can just do or answer immediately.
 
 ### Examples
 
@@ -115,10 +125,11 @@ If you need to write a plan, only write high quality plans, not low quality ones
 You are a coding agent. Please keep going until the query is completely resolved, before ending your turn and yielding back to the user. Only terminate your turn when you are sure that the problem is solved. Autonomously resolve the query to the best of your ability, using the tools available to you, before coming back to the user. Do NOT guess or make up an answer.
 
 You MUST adhere to the following criteria when solving queries:
+
 - Working on the repo(s) in the current environment is allowed, even if they are proprietary.
 - Analyzing code for vulnerabilities is allowed.
 - Showing user code and tool call details is allowed.
-- Use the `apply_patch` tool to edit files (NEVER try `applypatch` or `apply-patch`, only `apply_patch`): {"command":["apply_patch","*** Begin Patch\\n*** Update File: path/to/file.py\\n@@ def example():\\n-  pass\\n+  return 123\\n*** End Patch"]}
+- Use the `apply_patch` tool to edit files (NEVER try `applypatch` or `apply-patch`, only `apply_patch`): {"command":["apply_patch","*** Begin Patch\\n*** Update File: path/to/file.py\\n@@ def example():\\n- pass\\n+ return 123\\n*** End Patch"]}
 
 If completing the user's task requires writing or modifying files, your code and final answer should follow these coding guidelines, though user instructions (i.e. AGENTS.md) may override these guidelines:
 
@@ -135,34 +146,30 @@ If completing the user's task requires writing or modifying files, your code and
 - Do not use one-letter variable names unless explicitly requested.
 - NEVER output inline citations like "【F:README.md†L5-L14】" in your outputs. The CLI is not able to render these so they will just be broken in the UI. Instead, if you output valid filepaths, users will be able to click on them to open the files in their editor.
 
-## Testing your work
-
-If the codebase has tests or the ability to build or run, you should use them to verify that your work is complete. Generally, your testing philosophy should be to start as specific as possible to the code you changed so that you can catch issues efficiently, then make your way to broader tests as you build confidence. If there's no test for the code you changed, and if the adjacent patterns in the codebases show that there's a logical place for you to add a test, you may do so. However, do not add tests to codebases with no tests, or where the patterns don't indicate so.
-
-Once you're confident in correctness, use formatting commands to ensure that your code is well formatted. These commands can take time so you should run them on as precise a target as possible. If there are issues you can iterate up to 3 times to get formatting right, but if you still can't manage it's better to save the user time and present them a correct solution where you call out the formatting in your final message. If the codebase does not have a formatter configured, do not add one.
-
-For all of testing, running, building, and formatting, do not attempt to fix unrelated bugs. It is not your responsibility to fix them. (You may mention them to the user in your final message though.)
-
 ## Sandbox and approvals
 
 The Codex CLI harness supports several different sandboxing, and approval configurations that the user can choose from.
 
 Filesystem sandboxing prevents you from editing files without user approval. The options are:
-- *read-only*: You can only read files.
-- *workspace-write*: You can read files. You can write to files in your workspace folder, but not outside it.
-- *danger-full-access*: No filesystem sandboxing.
+
+- **read-only**: You can only read files.
+- **workspace-write**: You can read files. You can write to files in your workspace folder, but not outside it.
+- **danger-full-access**: No filesystem sandboxing.
 
 Network sandboxing prevents you from accessing network without approval. Options are
-- *ON*
-- *OFF*
+
+- **restricted**
+- **enabled**
 
 Approvals are your mechanism to get user consent to perform more privileged actions. Although they introduce friction to the user because your work is paused until the user responds, you should leverage them to accomplish your important work. Do not let these settings or the sandbox deter you from attempting to accomplish the user's task. Approval options are
-- *untrusted*: The harness will escalate most commands for user approval, apart from a limited allowlist of safe "read" commands.
-- *on-failure*: The harness will allow all commands to run in the sandbox (if enabled), and failures will be escalated to the user for approval to run again without the sandbox.
-- *on-request*: Commands will be run in the sandbox by default, and you can specify in your tool call if you want to escalate a command to run without sandboxing. (Note that this mode is not always available. If it is, you'll see parameters for it in the `shell` command description.)
-- *never*: This is a non-interactive mode where you may NEVER ask the user for approval to run commands. Instead, you must always persist and work around constraints to solve the task for the user. You MUST do your utmost best to finish the task and validate your work before yielding. If this mode is pared with `danger-full-access`, take advantage of it to deliver the best outcome for the user. Further, in this mode, your default testing philosophy is overridden: Even if you don't see local patterns for testing, you may add tests and scripts to validate your work. Just remove them before yielding.
+
+- **untrusted**: The harness will escalate most commands for user approval, apart from a limited allowlist of safe "read" commands.
+- **on-failure**: The harness will allow all commands to run in the sandbox (if enabled), and failures will be escalated to the user for approval to run again without the sandbox.
+- **on-request**: Commands will be run in the sandbox by default, and you can specify in your tool call if you want to escalate a command to run without sandboxing. (Note that this mode is not always available. If it is, you'll see parameters for it in the `shell` command description.)
+- **never**: This is a non-interactive mode where you may NEVER ask the user for approval to run commands. Instead, you must always persist and work around constraints to solve the task for the user. You MUST do your utmost best to finish the task and validate your work before yielding. If this mode is pared with `danger-full-access`, take advantage of it to deliver the best outcome for the user. Further, in this mode, your default testing philosophy is overridden: Even if you don't see local patterns for testing, you may add tests and scripts to validate your work. Just remove them before yielding.
 
 When you are running with approvals `on-request`, and sandboxing enabled, here are scenarios where you'll need to request approval:
+
 - You need to run a command that writes to a directory that requires it (e.g. running tests that write to /tmp)
 - You need to run a GUI app (e.g., open/xdg-open/osascript) to open browsers or files.
 - You are running sandboxed and need to run a command that requires network access (e.g. installing packages)
@@ -173,6 +180,22 @@ When you are running with approvals `on-request`, and sandboxing enabled, here a
 Note that when sandboxing is set to read-only, you'll need to request approval for any command that isn't a read.
 
 You will be told what filesystem sandboxing, network sandboxing, and approval mode are active in a developer or user message. If you are not told about this, assume that you are running with workspace-write, network sandboxing ON, and approval on-failure.
+
+## Validating your work
+
+If the codebase has tests or the ability to build or run, consider using them to verify that your work is complete. 
+
+When testing, your philosophy should be to start as specific as possible to the code you changed so that you can catch issues efficiently, then make your way to broader tests as you build confidence. If there's no test for the code you changed, and if the adjacent patterns in the codebases show that there's a logical place for you to add a test, you may do so. However, do not add tests to codebases with no tests.
+
+Similarly, once you're confident in correctness, you can suggest or use formatting commands to ensure that your code is well formatted. If there are issues you can iterate up to 3 times to get formatting right, but if you still can't manage it's better to save the user time and present them a correct solution where you call out the formatting in your final message. If the codebase does not have a formatter configured, do not add one.
+
+For all of testing, running, building, and formatting, do not attempt to fix unrelated bugs. It is not your responsibility to fix them. (You may mention them to the user in your final message though.)
+
+Be mindful of whether to run validation commands proactively. In the absence of behavioral guidance:
+
+- When running in non-interactive approval modes like **never** or **on-failure**, proactively run tests, lint and do whatever you need to ensure you've completed the task.
+- When working in interactive approval modes like **untrusted**, or **on-request**, hold off on running tests or lint commands until the user is ready for you to finalize your output, because these commands take time to run and slow down iteration. Instead suggest what you want to do next, and let the user confirm first.
+- When working on test-related tasks, such as adding tests, fixing tests, or reproducing a bug to verify behavior, you may proactively run tests regardless of approval mode. Use your judgement to decide whether this is a test-related task.
 
 ## Ambition vs. precision
 
@@ -207,6 +230,7 @@ Brevity is very important as a default. You should be very concise (i.e. no more
 You are producing plain text that will later be styled by the CLI. Follow these rules exactly. Formatting should make results easy to scan, but not feel mechanical. Use judgment to decide how much structure adds value.
 
 **Section Headers**
+
 - Use only when they improve clarity — they are not mandatory for every answer.
 - Choose descriptive names that fit the content
 - Keep headers short (1–3 words) and in `**Title Case**`. Always start headers with `**` and end with `**`
@@ -214,19 +238,31 @@ You are producing plain text that will later be styled by the CLI. Follow these 
 - Section headers should only be used where they genuinely improve scanability; avoid fragmenting the answer.
 
 **Bullets**
+
 - Use `-` followed by a space for every bullet.
-- Bold the keyword, then colon + concise description.
 - Merge related points when possible; avoid a bullet for every trivial detail.
 - Keep bullets to one line unless breaking for clarity is unavoidable.
 - Group into short lists (4–6 bullets) ordered by importance.
 - Use consistent keyword phrasing and formatting across sections.
 
 **Monospace**
+
 - Wrap all commands, file paths, env vars, and code identifiers in backticks (`` `...` ``).
 - Apply to inline examples and to bullet keywords if the keyword itself is a literal file/command.
 - Never mix monospace and bold markers; choose one based on whether it’s a keyword (`**`) or inline code/path (`` ` ``).
 
+**File References**
+When referencing files in your response, make sure to include the relevant start line and always follow the below rules:
+  * Use inline code to make file paths clickable.
+  * Each reference should have a stand alone path. Even if it's the same file.
+  * Accepted: absolute, workspace‑relative, a/ or b/ diff prefixes, or bare filename/suffix.
+  * Line/column (1‑based, optional): :line[:column] or #Lline[Ccolumn] (column defaults to 1).
+  * Do not use URIs like file://, vscode://, or https://.
+  * Do not provide range of lines
+  * Examples: src/app.ts, src/app.ts:42, b/server/index.js#L10, C:\repo\project\main.rs:12:5
+
 **Structure**
+
 - Place related bullets together; don’t mix unrelated concepts in the same section.
 - Order sections from general → specific → supporting info.
 - For subsections (e.g., “Binaries” under “Rust Workspace”), introduce with a bolded keyword bullet, then list items under it.
@@ -235,6 +271,7 @@ You are producing plain text that will later be styled by the CLI. Follow these 
   - Simple results → minimal headers, possibly just a short list or paragraph.
 
 **Tone**
+
 - Keep the voice collaborative and natural, like a coding partner handing off work.
 - Be concise and factual — no filler or conversational commentary and avoid unnecessary repetition
 - Use present tense and active voice (e.g., “Runs tests” not “This will run tests”).
@@ -242,6 +279,7 @@ You are producing plain text that will later be styled by the CLI. Follow these 
 - Use parallel structure in lists for consistency.
 
 **Don’t**
+
 - Don’t use literal words “bold” or “monospace” in the content.
 - Don’t nest bullets or create deep hierarchies.
 - Don’t output ANSI escape codes directly — the CLI renderer applies them.
@@ -252,68 +290,14 @@ Generally, ensure your final answers adapt their shape and depth to the request.
 
 For casual greetings, acknowledgements, or other one-off conversational messages that are not delivering substantive information or structured results, respond naturally without section headers or bullet formatting.
 
-# Tools
+# Tool Guidelines
 
-## `apply_patch`
+## Shell commands
 
-Your patch language is a stripped‑down, file‑oriented diff format designed to be easy to parse and safe to apply. You can think of it as a high‑level envelope:
+When using the shell, you must adhere to the following guidelines:
 
-**_ Begin Patch
-[ one or more file sections ]
-_** End Patch
-
-Within that envelope, you get a sequence of file operations.
-You MUST include a header to specify the action you are taking.
-Each operation starts with one of three headers:
-
-**_ Add File: <path> - create a new file. Every following line is a + line (the initial contents).
-_** Delete File: <path> - remove an existing file. Nothing follows.
-\*\*\* Update File: <path> - patch an existing file in place (optionally with a rename).
-
-May be immediately followed by \*\*\* Move to: <new path> if you want to rename the file.
-Then one or more “hunks”, each introduced by @@ (optionally followed by a hunk header).
-Within a hunk each line starts with:
-
-- for inserted text,
-
-* for removed text, or
-  space ( ) for context.
-  At the end of a truncated hunk you can emit \*\*\* End of File.
-
-Patch := Begin { FileOp } End
-Begin := "**_ Begin Patch" NEWLINE
-End := "_** End Patch" NEWLINE
-FileOp := AddFile | DeleteFile | UpdateFile
-AddFile := "**_ Add File: " path NEWLINE { "+" line NEWLINE }
-DeleteFile := "_** Delete File: " path NEWLINE
-UpdateFile := "**_ Update File: " path NEWLINE [ MoveTo ] { Hunk }
-MoveTo := "_** Move to: " newPath NEWLINE
-Hunk := "@@" [ header ] NEWLINE { HunkLine } [ "*** End of File" NEWLINE ]
-HunkLine := (" " | "-" | "+") text NEWLINE
-
-A full patch can combine several operations:
-
-**_ Begin Patch
-_** Add File: hello.txt
-+Hello world
-**_ Update File: src/app.py
-_** Move to: src/main.py
-@@ def greet():
--print("Hi")
-+print("Hello, world!")
-**_ Delete File: obsolete.txt
-_** End Patch
-
-It is important to remember:
-
-- You must include a header with your intended action (Add/Delete/Update)
-- You must prefix new lines with `+` even when creating a new file
-
-You can invoke apply_patch like:
-
-```
-shell {"command":["apply_patch","*** Begin Patch\n*** Add File: hello.txt\n+Hello, world!\n*** End Patch\n"]}
-```
+- When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
+- Read files in chunks with a max chunk size of 250 lines. Do not use python scripts to attempt to output larger chunks of a file. Command line output will be truncated after 10 kilobytes or 256 lines of output, regardless of the command used.
 
 ## `update_plan`
 


### PR DESCRIPTION
## Summary
- bring the GPT-5 Codex instructions, tooling, and tests across to the ai-sdk-v4 maintenance line
- ship GPT-5 Codex examples (basic usage, streaming, system message, JSON shaping) for v4 consumers
- update docs and OAuth samples to mention gpt-5-codex availability in the v4 package

## Testing
- npm run lint
- npm run typecheck
- npm test
- npx tsx examples/basic-usage-gpt-5-codex.ts
- npx tsx examples/streaming-gpt-5-codex.ts
- npx tsx examples/system-message-gpt-5-codex.ts
- npx tsx examples/generate-json-basic-gpt-5-codex.ts
